### PR TITLE
be able to build tcl/tk statically on linux

### DIFF
--- a/tk/interp/interp_unix.go
+++ b/tk/interp/interp_unix.go
@@ -18,7 +18,7 @@ import (
 #cgo darwin CFLAGS: -I/Library/Frameworks/Tcl.framework/Headers -I/Library/Frameworks/Tk.framework/Headers
 #cgo darwin LDFLAGS: -F/Library/Frameworks -framework tcl -framework tk
 #cgo linux CFLAGS: -I/usr/include/tcl
-#cgo linux LDFLAGS: -ltcl -ltk
+#cgo linux LDFLAGS: -ltcl -ltk -lX11 -lm -lz -ldl
 
 #include <tcl.h>
 #include <tk.h>


### PR DESCRIPTION
To build statically with `libtcl.a` and `libtk.a`, all necessary indirect dependencies i.g. `libX11`, `libm`, `libz`, `libdl` must be explicitly specified.
The PR is necessary to build an standalone app via [atkvfs](https://github.com/jopbrown/atkvfs).