### PR TITLE
turning C arrays into Go slices via 1<<30 not available on a 32-bits system and 1<<28 is enough

### DIFF
--- a/tk/interp/interp_unix.go
+++ b/tk/interp/interp_unix.go
@@ -506,7 +506,7 @@ func (o *ListObj) ToObjList() (list []*Obj) {
 	if objnum == 0 {
 		return
 	}
-	lst := (*[1 << 30]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
+	lst := (*[1 << 28]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
 	for _, v := range lst {
 		list = append(list, &Obj{v, o.interp})
 	}
@@ -520,7 +520,7 @@ func (o *ListObj) ToStringList() (list []string) {
 	if objnum == 0 {
 		return
 	}
-	lst := (*[1 << 30]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
+	lst := (*[1 << 28]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
 	var n C.int
 	for _, obj := range lst {
 		out := C.Tcl_GetStringFromObj(obj, &n)
@@ -536,7 +536,7 @@ func (o *ListObj) ToIntList() (list []int) {
 	if objnum == 0 {
 		return
 	}
-	lst := (*[1 << 30]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
+	lst := (*[1 << 28]*C.Tcl_Obj)(unsafe.Pointer(objs))[:int(objnum):int(objnum)]
 	var out C.Tcl_WideInt
 	for _, obj := range lst {
 		C.Tcl_GetWideIntFromObj(o.interp, obj, &out)


### PR DESCRIPTION
To turning C arrays into Go slices via `1 << 30` is not available on some 32-bits system.
```
$ go build
# github.com/visualfc/atk/tk/interp
/go/src/atk/tk/interp/interp_unix.go:509:11: type [1073741824]*_Ctype_struct_Tcl_Obj larger than address space
/go/src/atk/tk/interp/interp_unix.go:509:11: type [1073741824]*_Ctype_struct_Tcl_Obj too large
/go/src/atk/tk/interp/interp_unix.go:523:11: type [1073741824]*_Ctype_struct_Tcl_Obj larger than address space
/go/src/atk/tk/interp/interp_unix.go:523:11: type [1073741824]*_Ctype_struct_Tcl_Obj too large
/go/src/atk/tk/interp/interp_unix.go:539:11: type [1073741824]*_Ctype_struct_Tcl_Obj larger than address space
/go/src/atk/tk/interp/interp_unix.go:539:11: type [1073741824]*_Ctype_struct_Tcl_Obj too large
```

`1 << 28` is enough in all cases.
The [official cgo tutorial wiki](https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices) has [fixed](https://github.com/golang/go/wiki/cgo/_history) their example.