### PR TITLE
Add special handling of string-list attributes

### DIFF
--- a/tk/widget_type.go
+++ b/tk/widget_type.go
@@ -97,6 +97,12 @@ func buildWidgetAttributeScript(meta *MetaClass, ttk bool, attributes []*WidgetA
 		if !meta.HasAttribute(attr.key) {
 			continue
 		}
+		if strs, ok := attr.value.([]string); ok {
+			pname := "atk_tmp_" + attr.key
+			setObjTextList(pname, strs)
+			list = append(list, fmt.Sprintf("-%v $%v", attr.key, pname))
+			continue
+		}
 		if s, ok := attr.value.(string); ok {
 			pname := "atk_tmp_" + attr.key
 			setObjText(pname, s)


### PR DESCRIPTION
They should be passed to interpreter via setObjTextList otherwise Tcl interpreter does not recognize it as a string list.