### PR TITLE
tk/interp: use pkg-config on linux

### DIFF
--- a/tk/interp/interp_unix.go
+++ b/tk/interp/interp_unix.go
@@ -17,8 +17,7 @@ import (
 /*
 #cgo darwin CFLAGS: -I/Library/Frameworks/Tcl.framework/Headers -I/Library/Frameworks/Tk.framework/Headers
 #cgo darwin LDFLAGS: -F/Library/Frameworks -framework tcl -framework tk
-#cgo linux CFLAGS: -I/usr/include/tcl
-#cgo linux LDFLAGS: -ltcl -ltk -lX11 -lm -lz -ldl
+#cgo linux pkg-config: tcl tk
 
 #include <tcl.h>
 #include <tk.h>


### PR DESCRIPTION
On my distribution (Void Linux), `go get -u github.com/visualfc/atk/tk` gives the error:
```
# github.com/visualfc/atk/tk/interp
/bin/ld: cannot find -ltcl
/bin/ld: cannot find -ltk
collect2: error: ld returned 1 exit status
```

This is because on some systems the libraries are called `tcl8.6` and `tk8.6`.
Using pkg-config (documented [here](https://golang.org/cmd/cgo/)) fixes the problem. I don't know if it works on darwin too, if so you could simplify the code by using only that directive for all unix systems.